### PR TITLE
add humidity sensor and relative-humidity.current characteristics

### DIFF
--- a/lib/hap/characteristics/current_relative_humidity.ex
+++ b/lib/hap/characteristics/current_relative_humidity.ex
@@ -1,0 +1,15 @@
+defmodule HAP.Characteristics.CurrentRelativeHumidity do
+  @moduledoc """
+  Definition of the `public.hap.characteristic.relative-humidity.current` characteristic
+  """
+
+  @behaviour HAP.CharacteristicDefinition
+
+  def type, do: "10"
+  def perms, do: ["pr", "ev"]
+  def format, do: "float"
+  def min_value, do: 0
+  def max_value, do: 100
+  def step_value, do: 1
+  def unit, do: "percentage"
+end

--- a/lib/hap/services/humidity_sensor.ex
+++ b/lib/hap/services/humidity_sensor.ex
@@ -1,0 +1,25 @@
+defmodule HAP.Services.HumiditySensor do
+  @moduledoc """
+  Struct representing an instance of the `public.hap.service.sensor.humidity` service
+  """
+
+  defstruct current_relative_humidity: nil, name: nil, active: nil, fault: nil, tampered: nil, low_battery: nil
+
+  defimpl HAP.ServiceSource do
+    def compile(value) do
+      HAP.Service.ensure_required!(__MODULE__, "current_relative_humidity", value.current_relative_humidity)
+
+      %HAP.Service{
+        type: "82",
+        characteristics: [
+          {HAP.Characteristics.CurrentRelativeHumidity, value.current_relative_humidity},
+          {HAP.Characteristics.Name, value.name},
+          {HAP.Characteristics.StatusActive, value.active},
+          {HAP.Characteristics.StatusFault, value.fault},
+          {HAP.Characteristics.StatusTampered, value.tampered},
+          {HAP.Characteristics.StatusLowBattery, value.low_battery}
+        ]
+      }
+    end
+  end
+end


### PR DESCRIPTION
Tested/verified with homekit/real devices - below from spec.

great library - let me know if you want these PRs in a different format - I have some more Characteristics/Services ready..



**Sensor**

```
# 8.20
# Humidity Sensor
# This service describes a humidity sensor. This service requires iOS 9 or later.
# Property
# Value
# UUID
# Type
# Required Characteristics
# 00000082-0000-1000-8000-0026BB765291 public.hap.service.sensor.humidity
# ”9.34 Current Relative Humidity” (page 174)

# Optional Characteristics
# ”9.62 Name” (page 188)
# ”9.96 Status Active” (page 212) ”9.97 Status Fault” (page 212) ”9.100 Status Tampered” (page 214) ”9.99 Status Low Battery” (page 213)
```


**characteristic**
```
# 9.34 Current Relative Humidity
# This characteristic describes the current relative humidity of the accessoryʼs environment. The value is expressed as a percentage (%).
# Property
# Value
# UUID
# Type Permissions Format Minimum Value Maximum Value Step Value
# Unit
# 00000010-0000-1000-8000-0026BB765291 public.hap.characteristic.relative-humidity.current Paired Read, Notify
# float
# 0
# 100
# 1 percentage
```
