### PR TITLE
HAP.KinoDisplay for livebook usage

### DIFF
--- a/lib/hap/kino_display.ex
+++ b/lib/hap/kino_display.ex
@@ -1,0 +1,38 @@
+defmodule HAP.KinoDisplay do
+  @moduledoc false
+  # A Kino based implementation of the HAP.Display behaviour for livebook usage
+
+  @behaviour HAP.Display
+
+  @impl HAP.Display
+  def display_pairing_code(name, pairing_code, pairing_url) do
+    if Code.ensure_loaded?(Kino) do
+      png_qr_code =
+        pairing_url
+        |> EQRCode.encode()
+        |> EQRCode.png()
+        |> Base.encode64()
+
+      pairing_info =
+        Kino.Markdown.new("""
+        ### #{name} available for pairing. Connect using the following QR Code
+
+        ![qr code](data:image/png;base64,#{png_qr_code})
+
+        | Manual Setup Code |
+        | -- |
+        | #{pairing_code} |
+        """)
+
+      Kino.render(pairing_info)
+    else
+      IO.puts("Kino not available - use other HAP display module, or ensure Kino is installed")
+    end
+  end
+
+  @impl HAP.Display
+  def clear_pairing_code, do: :ok
+
+  @impl HAP.Display
+  def identify(name), do: IO.puts("Identifying #{name}")
+end


### PR DESCRIPTION
Convenience "Kino" HAP.Display implementation for livebook usage..

Long story short - livebook purposefully renders ANSI with 1,5 line height and in a scrollable max-height 300px textbox.. thus making the HAP pairing info output not that useful, and one has to resort to manual pairing.
<img width="937" alt="Screenshot 2021-10-06 at 22 11 04" src="https://user-images.githubusercontent.com/1033636/136277050-b66cc703-20d2-484d-a6cb-8e98e0d4112a.png">

with this PR rendering using Kino and `%HAP.AccessoryServer{.. display_module: HAP.KinoDisplay ..}`:

<img width="929" alt="Screenshot 2021-10-06 at 22 14 59" src="https://user-images.githubusercontent.com/1033636/136277228-6c5dc51a-a5e0-4358-9079-b0f59fdceb36.png">

Code should be guarded using Code.ensure_loaded?(Kino) and safe, but let's see with CI