### PR TITLE
lock bandit to 0.2.1 (as 0.2.3 has breaking changes)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule HAP.MixProject do
 
   defp deps do
     [
-      {:bandit, "~> 0.2.0"},
+      {:bandit, "0.2.1"},
       {:base36, "~> 1.0"},
       {:cubdb, "~> 0.17.0"},
       {:eqrcode, "~> 0.1.7"},


### PR DESCRIPTION
adding current hap to a new project will install bandit 0.2.3

problem is bandit 0.2.3 had breaking changes https://github.com/mtrudel/bandit/compare/0.2.1...0.2.3
especially `Bandit.HTTP1Request` (used by hap in HAPSessionHandler) renamed to `Bandit.HTTP1.Adapter`

maybe thousand_island needs locking as well?

with this and pending https://github.com/mtrudel/hap/pull/3 and https://github.com/mtrudel/hap/pull/4 - hap now "just works" out of the box - in something like nerves livebook, or just a newer nerves project..