### PR TITLE
nest docs per Services/Characteristics

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,6 +58,7 @@ defmodule HAP.MixProject do
   defp docs do
     [
       main: "HAP",
+      nest_modules_by_prefix: [HAP.Services, HAP.Characteristics],
       groups_for_modules: [
         Behaviours: [
           HAP.Display,


### PR DESCRIPTION
while looking at the docs and ways to improve them, I noticed the need for nesting https://hexdocs.pm/ex_doc/Mix.Tasks.Docs.html#module-nesting

before
<img width="1116" alt="Screenshot 2021-10-08 at 19 23 39" src="https://user-images.githubusercontent.com/1033636/136597982-55776a66-176b-4cbd-9fe9-61d98cbe5f76.png">

after
<img width="874" alt="Screenshot 2021-10-08 at 19 23 51" src="https://user-images.githubusercontent.com/1033636/136598011-673d93b7-154b-4a3e-a5e8-9dcd85355792.png">