### PR TITLE
fix test warning

### DIFF
--- a/test/hap/tlv_parser_test.exs
+++ b/test/hap/tlv_parser_test.exs
@@ -14,7 +14,7 @@ defmodule HAP.TLVParserTest do
     }
 
     {:ok, result, _conn} =
-      conn("METHOD", "path", data)
+      conn("METHOD", "/path", data)
       |> HAP.TLVParser.parse("application", "pairing+tlv8", {}, {})
 
     assert result == expected


### PR DESCRIPTION
warning: the URI path used in plug tests must start with "/", got: "path"
  (plug 1.14.0) lib/plug/adapters/test/conn.ex:13: Plug.Adapters.Test.Conn.conn/4